### PR TITLE
Jenkins update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,48 +1,9 @@
-String jdkVersion = 'Java 8'
+@Library(['private-pipeline-library', 'jenkins-shared']) _
 
-String mavenVersion = 'Maven 3.6.x'
-String mavenSettings = 'public-settings.xml'
-String mavenRepo = '.repo'
-String mavenOptions = '-V -B -e'
-
-pipeline {
-  options {
-    buildDiscarder(
-        logRotator(numToKeepStr: '100', daysToKeepStr: '14',  artifactNumToKeepStr: '20', artifactDaysToKeepStr: '10')
-    )
-    disableConcurrentBuilds()
-    timestamps()
-  }
-
-  agent {
-    label 'ubuntu-zion'
-  }
-
-  triggers {
-    pollSCM('*/15 * * * *')
-  }
-
-  tools {
-    maven mavenVersion
-    jdk jdkVersion
-  }
-
-  stages {
-    stage('Build') {
-      steps {
-        withMaven(maven: mavenVersion, jdk: jdkVersion, mavenSettingsConfig: mavenSettings, mavenLocalRepo: mavenRepo,
-            // disable automatic artifact publisher
-            options: [ artifactsPublisher(disabled: true) ]) {
-          sh "mvn $mavenOptions clean install"
-        }
-      }
-    }
-  }
-
-  post {
-    always {
-      // purge workspace after build finishes
-      deleteDir()
-    }
-  }
-}
+mavenPipeline(
+  mavenVersion: 'Maven 3.6.x',
+  javaVersion: 'Java 8',
+  usePublicSettingsXmlFile: true,
+  useEventSpy: false,
+  testResults: [ '**/target/*-reports/*.xml' ]
+)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <!--
 
-  Copyright (c) 2018-present Sonatype, Inc. All rights reserved.
+    Copyright (c) 2018-present Sonatype, Inc. All rights reserved.
 
-  This program is licensed to you under the Apache License Version 2.0,
-  and you may not use this file except in compliance with the Apache License Version 2.0.
-  You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License Version 2.0.
+    You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
 
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the Apache License Version 2.0 is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
 -->
 # Sonatype OSS Index - Public

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+<!--
+
+  Copyright (c) 2018-present Sonatype, Inc. All rights reserved.
+
+  This program is licensed to you under the Apache License Version 2.0,
+  and you may not use this file except in compliance with the Apache License Version 2.0.
+  You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the Apache License Version 2.0 is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+-->
 # Sonatype OSS Index - Public
 
 ![license](https://img.shields.io/github/license/sonatype/ossindex-public.svg)

--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,10 @@
+Copyright (c) 2018-present Sonatype, Inc. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.


### PR DESCRIPTION
Updates the Jenkinsfile to use the common maven pipeline.

It does not create a Jenkins artifact for the build artifacts.  If that is desired, we can add it, but it looks like originally was not storing artifacts in Jenkins.

Builds for this branch are at https://jenkins.ci.sonatype.dev/job/ossindex/job/ossindex-public/job/snapshot-builds/job/jenkins-update/

Snapshot builds are set up at https://jenkins.ci.sonatype.dev/job/ossindex/job/ossindex-public/job/snapshot-builds/ as multi-branch build.  It checks for updates every minute.

The release build is at https://jenkins.ci.sonatype.dev/job/ossindex/job/ossindex-public/job/release/  This PR will need to be merged before the release build is operational.

A similar release build is at https://jenkins.ci.sonatype.dev/job/cdi/job/examples/job/cdi-maven-example/job/release/ if you want to play with the behavior.

