### PR TITLE
Update dropwizard-support-testbase version to match internal usage

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>org.sonatype.goodies.dropwizard</groupId>
         <artifactId>dropwizard-support-testbase</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
(PR is part of codebase sync effort)

To keep the internal and external use of the testbase library aligned, update dropwizard-support-testbase version to latest.