### PR TITLE
Update API so that encoded characters in path parameters are allowed

### DIFF
--- a/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportEndpoint.java
+++ b/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportEndpoint.java
@@ -15,6 +15,7 @@ package org.sonatype.ossindex.service.api.componentreport;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -60,7 +61,7 @@ public interface ComponentReportEndpoint
       @ApiResponse(code = 429, message = "Too many requests")
   })
   @SuppressWarnings("RestParamTypeInspection")
-  ComponentReport get(@PathParam("coordinates") @ApiParam("Coordinates as package-url") PackageUrl coordinates);
+  ComponentReport get(@Encoded @PathParam("coordinates") @ApiParam("Coordinates as package-url") PackageUrl coordinates);
 
   @POST
   @Consumes({REQUEST_V1_JSON, APPLICATION_JSON})

--- a/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportEndpoint.java
+++ b/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportEndpoint.java
@@ -53,7 +53,7 @@ public interface ComponentReportEndpoint
   @GET
   @Path("{coordinates:.*}")
   @Produces({REPORT_V1_JSON, APPLICATION_JSON})
-  @ApiOperation(value = "Request vulnerability report for component")
+  @ApiOperation(value = "Request vulnerability report for component", hidden = true)
   @ApiResponses({
       @ApiResponse(code = 200, message = "Vulnerability report for component"),
       @ApiResponse(code = 404, message = "Component not found"),


### PR DESCRIPTION
This change addresses an issue where links to scoped npm packages resulted in 404s in the OSS Index service. Namespaces in npm include an `@` symbol. According to [purl-spec](https://github.com/package-url/purl-spec), that should be encoded as `%40`. However, the path param was being decoded into the `@` symbol, resulting in an invalid `PackageUrl`. Generally, most parts of purls use percent-encoded strings when necessary.

 The [JAX-RS javadocs](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/Encoded.html) state that the `@Encoded` attribute "disables automatic decoding of parameter values...". By disabling decoding, the coordinates path param can be read as intended.

Additionally, hide GET in the Swagger docs until an issue with the construction of encoded path params is resolved (separate issue open).

Internal references: OSSI-327, OSSI-336, and testsuite
