### PR TITLE
Upgrade Guava to address security vulnerabilities

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,11 +56,9 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Guava 20.x is the latest which supports Java 1.7 -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
     </dependency>
 
     <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,15 +58,12 @@
         <version>3.0.2</version>
       </dependency>
 
-      <!-- NOTE: guava 20.0 is also used by client+api due to it being the last version supporting Java 7 -->
-
+      <!-- NOTE: android version is used due to it supporting Java 7 -->
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.1-jre</version>
+        <version>29.0-android</version>
       </dependency>
-
-      <!-- NOTE: newer versions have incompatible byte-code -->
 
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -66,11 +66,9 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Guava 20.x is the latest which supports Java 1.7 -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR upgrades Guava to the latest compatible Android version.

Note: the comment in the pom.xml file regarding Guava 20.x and Java 7 is no longer applicable due to changes in the Guava project. According to the [Guava docs](https://github.com/google/guava):

> Guava comes in two flavors.
> - The JRE flavor requires JDK 1.8 or higher.
> - If you need support for JDK 1.7 or Android, use the Android flavor.

This project maintains a bom pom.xml, so the version is added only there for consistency. The bom/pom.xml previously declared version `28.0-jre` but that was omitted for conflict with 20.0:
```
[INFO] |  +- (com.google.guava:guava:jar:28.1-jre:compile - version managed from 20.0; omitted for conflict with 20.0)
```

This PR does not change the support for Java 7. The project uses the Maven Enforcer plugin to ensure compatibility with Java 7, which passes with `29.0-android`. For manual verification, it failed with version `29.0-jre`.
