### PR TITLE
Add externalReferences field to API models

### DIFF
--- a/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportVulnerability.java
+++ b/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportVulnerability.java
@@ -103,6 +103,16 @@ public class ComponentReportVulnerability
   @Nullable
   private List<String> versionRanges;
 
+  /**
+   * List of external references that provide additional information about the vulnerability
+   *
+   * @since 1.8.0
+   */
+  @ApiModelProperty("External references related to the vulnerability")
+  @JsonProperty
+  @XmlElement
+  private List<URI> externalReferences;
+
   public String getId() {
     return id;
   }
@@ -198,6 +208,20 @@ public class ComponentReportVulnerability
     this.versionRanges = versionRanges;
   }
 
+  /**
+   * @since 1.8.0
+   */
+  public List<URI> getExternalReferences() {
+    return externalReferences;
+  }
+
+  /**
+   * @since 1.8.0
+   */
+  public void setExternalReferences(final List<URI> externalReferences) {
+    this.externalReferences = externalReferences;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -216,12 +240,14 @@ public class ComponentReportVulnerability
         Objects.equals(cwe, that.cwe) &&
         Objects.equals(cve, that.cve) &&
         Objects.equals(reference, that.reference) &&
-        Objects.equals(versionRanges, that.versionRanges);
+        Objects.equals(versionRanges, that.versionRanges) &&
+        Objects.equals(externalReferences, that.externalReferences);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, displayName, title, description, cvssScore, cvssVector, cwe, cve, reference, versionRanges);
+    return Objects.hash(id, displayName, title, description, cvssScore, cvssVector, cwe, cve, reference, versionRanges,
+        externalReferences);
   }
 
   @Override


### PR DESCRIPTION
In preparation for an upcoming addition to the OSS Index API, add an `externalReferences` field to the public models used by the API.

References:
https://github.com/OSSIndex/vulns/issues/193