### PR TITLE
Update getExternalReferences() to return an empty list instead of null

### DIFF
--- a/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportVulnerability.java
+++ b/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportVulnerability.java
@@ -14,6 +14,7 @@ package org.sonatype.ossindex.service.api.componentreport;
 
 import java.io.Serializable;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -212,6 +213,9 @@ public class ComponentReportVulnerability
    * @since 1.8.0
    */
   public List<URI> getExternalReferences() {
+    if (externalReferences == null) {
+      externalReferences = new ArrayList<>();
+    }
     return externalReferences;
   }
 


### PR DESCRIPTION
This PR is a fix for #29. While the data _should_ contain at least one reference, and the server-side API will always return an empty list if there are no references (internal code), this change updates `getExternalReferences()` to return an empty list in the case where `externalReferences` is null. The approach is similar to other methods [[1]](https://github.com/sonatype/ossindex-public/blob/27d7bac26b1673ea8ed07151cb34c084bb7d7e64/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReport.java#L95) [[2]](https://github.com/sonatype/ossindex-public/blob/27d7bac26b1673ea8ed07151cb34c084bb7d7e64/api/src/main/java/org/sonatype/ossindex/service/api/componentreport/ComponentReportRequest.java#L65) in this code base where a field is not marked as `@Nullable`.
